### PR TITLE
Custom assertion messages for Snowhouse

### DIFF
--- a/include/snowhouse/withmessagewrapper.h
+++ b/include/snowhouse/withmessagewrapper.h
@@ -1,0 +1,47 @@
+//          Copyright Joakim Karlsson & Kim Gräsman 2010-2012.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef SNOWHOUSE_WITHMESSAGEWRAPPER_H
+#define SNOWHOUSE_WITHMESSAGEWRAPPER_H
+
+#include "constraints/expressions/expression.h"
+
+namespace snowhouse
+{
+
+    template<typename InnerExpression>
+    struct WithMessageWrapper //: Expression<WithMessageWrapper<InnerExpression>>
+    {
+        WithMessageWrapper(const InnerExpression& expr, const std::string& msg)
+            :m_expr{ expr }, m_msg{ msg }
+        {
+        }
+
+        template<typename ActualType>
+        bool operator()(const ActualType& actual) const
+        {
+            return m_expr(actual);
+        }
+
+        const InnerExpression m_expr;
+        const std::string     m_msg;
+    };
+
+    template<typename InnerExpression>
+    struct Stringizer<WithMessageWrapper<InnerExpression>>
+    {
+        static std::string ToString(const WithMessageWrapper<InnerExpression>& expr)
+        {
+            return Stringize(expr.m_expr);
+        }
+    };
+
+    template<typename InnerExpression>
+    WithMessageWrapper<InnerExpression>WithMessage(const InnerExpression& expr, const std::string& msg) {
+        return WithMessageWrapper<InnerExpression>(expr, msg);
+    }
+}
+
+#endif


### PR DESCRIPTION
Attempt to extend Snowhouse assertions to make them able to accept custom assertion messages.

General idea: overload of `Assert::That` which accepts a wrapper of a Snowhouse `Expression` with additional message string. `DefaultFailureHandler` accepts such additional string and adds it to assertion messages, if provided.


Example:

```cpp
Assert::That(
    shortestDistance(1, 2, 3), 
    WithMessage(
        EqualsWithDelta(4.242640687, 1e-9), 
        "Invalid result for input: x=1, y=2, z=3"
    )
);
```

```text
<FAILED::>Invalid result for input: x=1, y=2, z=3<:LF:>Expected: equal to 4.24264 (+/- 1e-09)<:LF:>Actual: 5.24264<:LF:>
```

Pros:
- Backwards compatible, should not modify behavior of existing code in any way.
- Should work with any Snowhouse expression, not only `Equals`.

Cons:
- The fork modifies files of Snowhouse and does not realize its goal just by using extension points available in the framework.
- Syntax is rather clumsy, because main goal was to modify original Snowhouse as little as possible (see "Potential improvements" below).
- Does not provide three-argument variant of `AssertThat` macro. Can be used only as `Assert::That`

TODOs:
- Provide additional overloads of `Assert::That` which would work with `bool`, fluent expressions, `const char*`, etc.
- Document.

Potential improvements:
- Assertion syntax could be improved in one of following ways:
  - Provide a variant of `AssertThat` macro which would accept three arguments. Macro overloading, yay!
  - Provide some better way to create a message wrapper, for example `EqualsWithDelta(4.242640687, 1e-9).WithMessage("Invalid result for input: x=1, y=2, z=3")`. Would require modification of `Expression`.

Credits:

Inspired by user [MikChan](https://www.codewars.com/users/5de83a82bdfc590018f30f6a) and [his idea](https://www.codewars.com/kumite/607e94693d4a0d0006c63c32?sel=607ecf00eea8bf000755007d).