### PR TITLE
Add overloads to show additional custom message on failure

### DIFF
--- a/assert.h
+++ b/assert.h
@@ -34,7 +34,7 @@ namespace snowhouse
 
   inline auto ExtraMessage(const std::string& msg)
   {
-    return [&]() { return msg; };
+    return [msg]() { return msg; };
   }
 
   struct DefaultFailureHandler

--- a/assert.h
+++ b/assert.h
@@ -33,7 +33,7 @@ namespace snowhouse
     {
       std::ostringstream str;
 
-      if (message.length()) {
+      if (!message.empty()) {
           str << message << std::endl;
       }
 

--- a/assert.h
+++ b/assert.h
@@ -10,6 +10,7 @@
 #include "fluent/expressionbuilder.h"
 
 #include <string>
+#include <sstream>
 
 // clang-format off
 #define SNOWHOUSE_ASSERT_THAT(P1, P2, FAILURE_HANDLER) \
@@ -37,6 +38,37 @@ namespace snowhouse
 
     MessageStringSupplier AssertionMessage(const std::string& message) {
         return MessageStringSupplier(message);
+    }
+
+    struct MessageStreamSupplier {
+
+        MessageStreamSupplier() { }
+
+        explicit
+        MessageStreamSupplier(const std::string& message) {
+            m_str << message;
+        }
+
+        std::string operator()() const {
+            return m_str.str();
+        }
+
+        template <typename T>
+        MessageStreamSupplier& operator<< (const T& msgItem) {
+            m_str << msgItem;
+            return *this;
+        }
+
+        private:
+            std::ostringstream m_str;
+    };
+
+
+    MessageStreamSupplier MessageBuilder(const std::string& messagePrefix) {
+        return MessageStreamSupplier(messagePrefix);
+    }
+    MessageStreamSupplier MessageBuilder() {
+        return MessageStreamSupplier();
     }
 
   struct DefaultFailureHandler

--- a/assert.h
+++ b/assert.h
@@ -24,7 +24,18 @@
 
 namespace snowhouse
 {
-  auto WithMessage = [](const std::string& msg) { return [&]() { return msg; }; };
+  namespace detail
+  {
+    inline std::string EmptyMessage()
+    { 
+      return std::string();
+    }
+  }
+
+  inline auto ExtraMessage(const std::string& msg)
+  {
+    return [&]() { return msg; };
+  }
 
   struct DefaultFailureHandler
   {
@@ -34,7 +45,7 @@ namespace snowhouse
       std::ostringstream str;
 
       if (!message.empty()) {
-          str << message << std::endl;
+        str << message << std::endl;
       }
 
       str << "Expected: " << snowhouse::Stringize(expected) << std::endl;
@@ -46,7 +57,7 @@ namespace snowhouse
     template<typename ExpectedType, typename ActualType>
     static void Handle(const ExpectedType& expected, const ActualType& actual, const char* file_name, int line_number)
     {
-        Handle(expected, actual, "", file_name, line_number);
+      Handle(expected, actual, "", file_name, line_number);
     }
 
     static void Handle(const std::string& message)
@@ -60,7 +71,7 @@ namespace snowhouse
   {
 
     template<typename ActualType, typename ConstraintListType, typename MessageSupplierType>
-    static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const MessageSupplierType& messageSupplier, const char* file_name = "", int line_number = 0)
+    static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const MessageSupplierType& message_supplier, const char* file_name = "", int line_number = 0)
     {
       try
       {
@@ -82,7 +93,7 @@ namespace snowhouse
 
         if (!result.top())
         {
-          FailureHandler::Handle(expression, actual, messageSupplier(), file_name, line_number);
+          FailureHandler::Handle(expression, actual, message_supplier(), file_name, line_number);
         }
       }
       catch (const InvalidExpressionException& e)
@@ -94,72 +105,54 @@ namespace snowhouse
     template<typename ActualType, typename ConstraintListType>
     static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
-        That(actual, expression, []() { return std::string(); }, file_name, line_number);
+      That(actual, expression, detail::EmptyMessage, file_name, line_number);
     }
 
     template<typename ConstraintListType, typename MessageSupplierType>
-    static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const MessageSupplierType& messageSupplier, const char* file_name = "", int line_number = 0)
+    static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const MessageSupplierType& message_supplier, const char* file_name = "", int line_number = 0)
     {
-        return That(std::string(actual), expression, messageSupplier, file_name, line_number);
+      return That(std::string(actual), expression, message_supplier, file_name, line_number);
     }
 
     template<typename ConstraintListType>
     static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
-      return That(actual, expression, []() { return std::string(); }, file_name, line_number);
+      return That(actual, expression, detail::EmptyMessage, file_name, line_number);
     }
 
     template<typename ActualType, typename ExpressionType, typename MessageSupplierType>
-    static void That(const ActualType& actual, const ExpressionType& expression, const MessageSupplierType& messageSupplier, const char* file_name = "", int line_number = 0)
+    static void That(const ActualType& actual, const ExpressionType& expression, const MessageSupplierType& message_supplier, const char* file_name = "", int line_number = 0)
     {
-        if (!expression(actual))
-        {
-            FailureHandler::Handle(expression, actual, messageSupplier(), file_name, line_number);
-        }
+      if (!expression(actual))
+      {
+        FailureHandler::Handle(expression, actual, message_supplier(), file_name, line_number);
+      }
     }
 
     template<typename ActualType, typename ExpressionType>
     static void That(const ActualType& actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
-        That(actual, expression, []() { return std::string(); }, file_name, line_number);
+      That(actual, expression, detail::EmptyMessage, file_name, line_number);
     }
 
     template<typename ExpressionType, typename MessageSupplierType>
-    static void That(const char* actual, const ExpressionType& expression, const MessageSupplierType& messageSupplier, const char* file_name = "", int line_number = 0)
+    static void That(const char* actual, const ExpressionType& expression, const MessageSupplierType& message_supplier, const char* file_name = "", int line_number = 0)
     {
-        return That(std::string(actual), expression, messageSupplier, file_name, line_number);
+      return That(std::string(actual), expression, message_supplier, file_name, line_number);
     }
 
     template<typename ExpressionType>
     static void That(const char* actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
-      return That(actual, expression, []() { return std::string(); },  file_name, line_number);
+      return That(actual, expression, detail::EmptyMessage,  file_name, line_number);
     }
 
-    /*
-    //Unfortunately, this overload ends up being ambigous and clashes with existing ones.
-    //Can be fixed with traits or a bit of metaprogramming, but do not know how ;) Yet.
-    //To assert on booleans with a custom message, one can use `Assert::That(boolvalue, IsTrue(), msgsupplier)` or
-    //`Assert::That(boolvalue, Is().True(), msgsupplier)` (or respective equivalents `IsFalse()`/`Is().False()`.
-    template <typename MessageSupplierType>
-    static void That(bool actual, const MessageSupplierType& messageSupplier)
-    {
-        if (!actual)
-        {
-            std::string customMessage = messageSupplier();
-            std::string originalMessage("Expected: true\nActual: false");
-
-            std::string message = customMessage.length() ? (customMessage + '\n' + originalMessage) : originalMessage;
-            FailureHandler::Handle(message);
-        }
-    }    
-    */
     static void That(bool actual)
     {
-        if (!actual)
-        {
-            FailureHandler::Handle("Expected: true\nActual: false");
-        }
+      if (!actual)
+      {
+        FailureHandler::Handle("Expected: true\nActual: false");
+      }
     }
 
     static void Failure(const std::string& message)

--- a/assert.h
+++ b/assert.h
@@ -24,55 +24,7 @@
 
 namespace snowhouse
 {
-    struct EmptyMessageSupplier {
-        std::string operator()() const { return ""; }
-    };
-
-    struct MessageStringSupplier {
-
-        explicit MessageStringSupplier(const std::string& message) : m_str(message) { }
-
-        std::string operator()() const {
-            return m_str;
-        }
-
-        const std::string m_str;
-    };
-
-    MessageStringSupplier AssertionMessage(const std::string& message) {
-        return MessageStringSupplier(message);
-    }
-
-    struct MessageStreamSupplier {
-
-        MessageStreamSupplier() { }
-
-        explicit
-        MessageStreamSupplier(const std::string& message) {
-            m_str << message;
-        }
-
-        std::string operator()() const {
-            return m_str.str();
-        }
-
-        template <typename T>
-        MessageStreamSupplier& operator<< (const T& msgItem) {
-            m_str << msgItem;
-            return *this;
-        }
-
-        private:
-            std::ostringstream m_str;
-    };
-
-
-    MessageStreamSupplier MessageBuilder(const std::string& messagePrefix) {
-        return MessageStreamSupplier(messagePrefix);
-    }
-    MessageStreamSupplier MessageBuilder() {
-        return MessageStreamSupplier();
-    }
+  auto WithMessage = [](const std::string& msg) { return [&]() { return msg; }; };
 
   struct DefaultFailureHandler
   {
@@ -106,6 +58,7 @@ namespace snowhouse
   template<typename FailureHandler>
   struct ConfigurableAssert
   {
+
     template<typename ActualType, typename ConstraintListType, typename MessageSupplierType>
     static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const MessageSupplierType& messageSupplier, const char* file_name = "", int line_number = 0)
     {
@@ -141,7 +94,7 @@ namespace snowhouse
     template<typename ActualType, typename ConstraintListType>
     static void That(const ActualType& actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
-        That(actual, expression, EmptyMessageSupplier(), file_name, line_number);
+        That(actual, expression, []() { return std::string(); }, file_name, line_number);
     }
 
     template<typename ConstraintListType, typename MessageSupplierType>
@@ -153,7 +106,7 @@ namespace snowhouse
     template<typename ConstraintListType>
     static void That(const char* actual, ExpressionBuilder<ConstraintListType> expression, const char* file_name = "", int line_number = 0)
     {
-      return That(actual, expression, EmptyMessageSupplier(), file_name, line_number);
+      return That(actual, expression, []() { return std::string(); }, file_name, line_number);
     }
 
     template<typename ActualType, typename ExpressionType, typename MessageSupplierType>
@@ -168,7 +121,7 @@ namespace snowhouse
     template<typename ActualType, typename ExpressionType>
     static void That(const ActualType& actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
-        That(actual, expression, EmptyMessageSupplier(), file_name, line_number);
+        That(actual, expression, []() { return std::string(); }, file_name, line_number);
     }
 
     template<typename ExpressionType, typename MessageSupplierType>
@@ -180,7 +133,7 @@ namespace snowhouse
     template<typename ExpressionType>
     static void That(const char* actual, const ExpressionType& expression, const char* file_name = "", int line_number = 0)
     {
-      return That(actual, expression, EmptyMessageSupplier(),  file_name, line_number);
+      return That(actual, expression, []() { return std::string(); },  file_name, line_number);
     }
 
     /*


### PR DESCRIPTION
Another iteration on idea from https://github.com/codewars/snowhouse/pull/1#issuecomment-824381241 .

Proposed API:

```cpp
Assert::That(
    shortestDistance(1, 2, 3), 
    EqualsWithDelta(4.242640687, 1e-9), 
    ExtraMessage("Invalid result for input: x=1, y=2, z=3")
);
```

`MessageSupplierType` type parameter of `Assert::That` would allow for different implementations of message suppliers. `MessageStringSupplier` is provided by default and can be constructed with `ExtraMessage` convenience function, but it would be possible to create other suppliers too, for example utilising string streams or  `{fmt}`.